### PR TITLE
preliminary version: split deploy into three

### DIFF
--- a/.github/workflows/deploy_application.yml
+++ b/.github/workflows/deploy_application.yml
@@ -1,0 +1,72 @@
+name: Deploy Application
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * *'  # Daily at midnight
+
+jobs:
+  deploy_application:
+    runs-on: ubuntu-latest
+    environment: ${{ github.ref == 'refs/heads/prod' && 'production' || github.ref == 'refs/heads/stage' && 'staging' || 'development' }}
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set Environment
+        run: |
+          if [[ "${{ github.ref }}" == "refs/heads/prod" ]]; then
+            echo "ENVIRONMENT=production" >> $GITHUB_ENV
+          elif [[ "${{ github.ref }}" == "refs/heads/stage" ]]; then
+            echo "ENVIRONMENT=staging" >> $GITHUB_ENV
+          else
+            echo "ENVIRONMENT=development" >> $GITHUB_ENV
+          fi
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+
+      - name: Build, tag, and push image to Amazon ECR
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          ECR_REPOSITORY: credex-core-${{ env.ENVIRONMENT }}
+          IMAGE_TAG: ${{ github.sha }}
+        run: |
+          docker build --target $ENVIRONMENT -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+          echo "IMAGE=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" >> $GITHUB_ENV
+
+      - name: Update ECS Task Definition
+        run: |
+          TASK_DEF_NAME="credex-core-${ENVIRONMENT}"
+          TASK_DEF=$(aws ecs describe-task-definition --task-definition $TASK_DEF_NAME --query taskDefinition)
+          NEW_TASK_DEF=$(echo $TASK_DEF | jq '.containerDefinitions[0].image = env.IMAGE')
+          echo $NEW_TASK_DEF > new-task-def.json
+          NEW_TASK_DEF_ARN=$(aws ecs register-task-definition --cli-input-json file://new-task-def.json --query 'taskDefinition.taskDefinitionArn' --output text)
+          echo "NEW_TASK_DEF_ARN=$NEW_TASK_DEF_ARN" >> $GITHUB_ENV
+
+      - name: Deploy to ECS
+        run: |
+          aws ecs update-service --cluster credex-cluster-$ENVIRONMENT --service credex-core-service-$ENVIRONMENT --task-definition $NEW_TASK_DEF_ARN
+          echo "Waiting for service to stabilize..."
+          aws ecs wait services-stable --cluster credex-cluster-$ENVIRONMENT --services credex-core-service-$ENVIRONMENT
+
+      - name: Generate JWT Token
+        run: |
+          JWT_SECRET=$(openssl rand -base64 32)
+          echo "JWT_SECRET=$JWT_SECRET" >> $GITHUB_ENV
+
+      - name: Print Deployment Information
+        run: |
+          echo "Please manually add the following secret to your GitHub repository for the $ENVIRONMENT environment:"
+          echo "JWT_SECRET: $JWT_SECRET"
+          echo "Deployment completed successfully. New task definition ARN: $NEW_TASK_DEF_ARN"

--- a/.github/workflows/deploy_application_infrastructure.yml
+++ b/.github/workflows/deploy_application_infrastructure.yml
@@ -1,0 +1,54 @@
+name: Deploy Application Infrastructure
+
+on:
+  workflow_dispatch:
+
+jobs:
+  deploy_infrastructure:
+    runs-on: ubuntu-latest
+    environment: ${{ github.ref == 'refs/heads/prod' && 'production' || github.ref == 'refs/heads/stage' && 'staging' || 'development' }}
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set Environment
+        run: |
+          if [[ "${{ github.ref }}" == "refs/heads/prod" ]]; then
+            echo "ENVIRONMENT=production" >> $GITHUB_ENV
+          elif [[ "${{ github.ref }}" == "refs/heads/stage" ]]; then
+            echo "ENVIRONMENT=staging" >> $GITHUB_ENV
+          else
+            echo "ENVIRONMENT=development" >> $GITHUB_ENV
+          fi
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v2
+
+      - name: Terraform Init and Apply for Application Infrastructure
+        run: |
+          cd terraform
+          terraform init
+          terraform workspace select $ENVIRONMENT || terraform workspace new $ENVIRONMENT
+          terraform apply -auto-approve -target=module.ecs -target=module.vpc -target=module.security_groups
+
+      - name: Get Infrastructure Outputs
+        run: |
+          cd terraform
+          echo "ECR_REPO_URL=$(terraform output -raw ecr_repository_url)" >> $GITHUB_ENV
+          echo "ECS_CLUSTER_ARN=$(terraform output -raw ecs_cluster_arn)" >> $GITHUB_ENV
+          echo "ECS_TASK_DEF_ARN=$(terraform output -raw ecs_task_definition_arn)" >> $GITHUB_ENV
+
+      - name: Print Infrastructure Information
+        run: |
+          echo "Please manually add the following secrets to your GitHub repository for the $ENVIRONMENT environment:"
+          echo "ECR_REPO_URL: $ECR_REPO_URL"
+          echo "ECS_CLUSTER_ARN: $ECS_CLUSTER_ARN"
+          echo "ECS_TASK_DEF_ARN: $ECS_TASK_DEF_ARN"

--- a/.github/workflows/deploy_neo4j.yml
+++ b/.github/workflows/deploy_neo4j.yml
@@ -1,0 +1,60 @@
+name: Deploy Neo4j
+
+on:
+  workflow_dispatch:
+
+jobs:
+  deploy_neo4j:
+    runs-on: ubuntu-latest
+    environment: ${{ github.ref == 'refs/heads/prod' && 'production' || github.ref == 'refs/heads/stage' && 'staging' || 'development' }}
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set Environment
+        run: |
+          if [[ "${{ github.ref }}" == "refs/heads/prod" ]]; then
+            echo "ENVIRONMENT=production" >> $GITHUB_ENV
+          elif [[ "${{ github.ref }}" == "refs/heads/stage" ]]; then
+            echo "ENVIRONMENT=staging" >> $GITHUB_ENV
+          else
+            echo "ENVIRONMENT=development" >> $GITHUB_ENV
+          fi
+
+      - name: Generate Neo4j Credentials
+        run: |
+          NEO4J_LEDGER_USER="neo4j$(openssl rand -base64 8 | tr -dc '0-9' | fold -w 6 | head -n 1)"
+          NEO4J_SEARCH_USER="neo4j$(openssl rand -base64 8 | tr -dc '0-9' | fold -w 6 | head -n 1)"
+          NEO4J_LEDGER_PASS=$(openssl rand -base64 32)
+          NEO4J_SEARCH_PASS=$(openssl rand -base64 32)
+          echo "NEO4J_LEDGER_USER=$NEO4J_LEDGER_USER" >> $GITHUB_ENV
+          echo "NEO4J_SEARCH_USER=$NEO4J_SEARCH_USER" >> $GITHUB_ENV
+          echo "NEO4J_LEDGER_PASS=$NEO4J_LEDGER_PASS" >> $GITHUB_ENV
+          echo "NEO4J_SEARCH_PASS=$NEO4J_SEARCH_PASS" >> $GITHUB_ENV
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v2
+
+      - name: Terraform Init and Apply for Neo4j
+        run: |
+          cd terraform
+          terraform init
+          terraform workspace select $ENVIRONMENT || terraform workspace new $ENVIRONMENT
+          terraform apply -auto-approve -target=module.neo4j
+
+      - name: Get Neo4j Outputs
+        run: |
+          cd terraform
+          echo "NEO4J_LEDGER_URL=$(terraform output -raw neo4j_ledger_space_bolt_url)" >> $GITHUB_ENV
+          echo "NEO4J_SEARCH_URL=$(terraform output -raw neo4j_search_space_bolt_url)" >> $GITHUB_ENV
+
+      - name: Print Neo4j Information
+        run: |
+          echo "Please manually add the following secrets to your GitHub repository for the $ENVIRONMENT environment:"
+          echo "NEO4J_LEDGER_BOLT_URL: $NEO4J_LEDGER_URL"
+          echo "NEO4J_SEARCH_BOLT_URL: $NEO4J_SEARCH_URL"
+          echo "NEO4J_LEDGER_USER: $NEO4J_LEDGER_USER"
+          echo "NEO4J_LEDGER_PASS: $NEO4J_LEDGER_PASS"
+          echo "NEO4J_SEARCH_USER: $NEO4J_SEARCH_USER"
+          echo "NEO4J_SEARCH_PASS: $NEO4J_SEARCH_PASS"


### PR DESCRIPTION
This commit moves towards splitting create.yml into:

### deploy_application.yml
   - Implements CI/CD pipeline for deploying the application
   - Includes steps for building Docker image, pushing to ECR, updating ECS task definition, and deploying to ECS
   - Generates and outputs a JWT secret

### deploy_application_infrastructure.yml
   - Implements infrastructure deployment using Terraform
   - Sets up ECS, VPC, and security groups
   - Outputs important infrastructure information like ECR repo URL and ECS cluster ARN

### deploy_neo4j.yml
   - Implements deployment of Neo4j databases
   - Generates Neo4j credentials
   - Sets up Neo4j infrastructure using Terraform
   - Outputs Neo4j connection information and credentials

These changes introduce new CI/CD workflows for deploying the application, its infrastructure, and Neo4j databases. They improve the automation of the deployment process and provide better management of environment-specific configurations.

**This imerge is done untested because the workflows need to exist in dev to run them on any branch. Changes and bug fixes expected.**