### PR TITLE
Merge deploy-docs-forwarders into dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,6 @@
 
 The credex ecosystem is a shared ledger that enables the efficient circulation of value, accumulation of capital, investment of profits, and giving of gifts. Credex is a tool for financial inclusion, financial empowerment, and financial sovereignty.
 
-This credex-core API, deployed at mycredex.app, is the portal through which members access their sovereign financial rights on the shared ledger and sidestep the economic distortions and extortions imposed by obsolete and destructive monetary paradigms.
+This credex-core API, deployed at mycredex.app, is the portal through which members access their sovereign financial rights on the shared ledger, and sidestep the economic distortions and extortions imposed by obsolete and destructive monetary paradigms.
 
 [docs.mycredex.app](https://docs.mycredex.app)


### PR DESCRIPTION
This PR updates the CloudFront and load balancer configurations for the documentation site. It fulfills two purposes:

1. forwarder from root (mycredex.app in prod) to docs subdomain (docs.mycredex.app in prod)
2. the solution of serving index.html at the root of the docs subdomain breaks the loading of menu.js, so we are also adding a forwarder in CloudFront to manage this secondary forwarding.

Key Changes:
- Added custom error responses (403, 404) in CloudFront to redirect to /index.html
- Updated load balancer listener default action to redirect to docs subdomain
- Modified docs listener rule to use HTTP 301 redirect instead of fixed-response

These changes improve the documentation site's routing and error handling by:
1. Ensuring proper SPA behavior by redirecting errors to index.html
3. Implementing proper redirects from main domain to docs subdomain
4. Using permanent redirects (HTTP 301) for better SEO and caching