### PR TITLE
Fix Request ID Tracking in Digital Signature Flow

### DIFF
--- a/src/api/Credex/controllers/acceptCredex.ts
+++ b/src/api/Credex/controllers/acceptCredex.ts
@@ -19,10 +19,20 @@ export async function AcceptCredexController(
   res: express.Response
 ) {
   const requestId = req.id;
-  logger.debug("AcceptCredexController called", { requestId, body: req.body });
+  logger.debug("AcceptCredexController called", { 
+    body: req.body, 
+    requestId,
+    context: 'AcceptCredexController'
+  });
 
   try {
     const { credexID, signerID } = req.body;
+
+    logger.debug("RequestId check", {
+      requestId,
+      hasRequestId: !!requestId,
+      context: 'AcceptCredexController'
+    });
 
     if (!validateUUID(credexID)) {
       logger.warn("Invalid credexID provided", { credexID, requestId });
@@ -38,13 +48,14 @@ export async function AcceptCredexController(
       credexID,
       signerID,
       requestId,
+      context: 'AcceptCredexController'
     });
     const acceptCredexData = await AcceptCredexService(
       credexID,
       signerID,
       requestId
     );
-
+    
     if (!acceptCredexData) {
       logger.warn("Failed to accept Credex", { credexID, signerID, requestId });
       return res.status(400).json({ error: "Failed to accept Credex" });

--- a/src/api/Credex/services/AcceptCredex.ts
+++ b/src/api/Credex/services/AcceptCredex.ts
@@ -27,23 +27,53 @@ export async function AcceptCredexService(
 ): Promise<AcceptCredexResult | null> {
   logDebug(`Entering AcceptCredexService`, { credexID, signerID, requestId });
 
-  if (!credexID || !signerID) {
-    logError("AcceptCredexService: credexID and signerID are required", new Error("Missing parameters"), { credexID, signerID, requestId });
+  if (!credexID || !signerID || !requestId) {
+    logError("AcceptCredexService: Missing required parameters", new Error("Missing parameters"), { credexID, signerID, requestId });
     return null;
   }
 
   const ledgerSpaceSession = ledgerSpaceDriver.session();
 
   try {
-    logDebug(`Attempting to accept Credex in database`, { credexID, signerID, requestId });
+    logDebug(`Attempting to accept Credex in database`, { 
+      credexID, 
+      signerID, 
+      requestId,
+      sessionState: ledgerSpaceSession.lastBookmark() 
+    });
 
     const result = await ledgerSpaceSession.executeWrite(async (tx) => {
+      // First, verify the nodes exist
+      const verifyQuery = `
+        MATCH (credex:Credex {credexID: $credexID})
+        MATCH (signer:Member|Avatar {memberID: $signerID})
+        RETURN 
+          credex IS NOT NULL as credexExists,
+          signer IS NOT NULL as signerExists
+      `;
+      
+      const verifyResult = await tx.run(verifyQuery, { credexID, signerID });
+      
+      if (verifyResult.records.length === 0) {
+        logError("Verification failed - Credex or Signer not found", new Error("Entities not found"), {
+          credexID,
+          signerID,
+          requestId
+        });
+        return null;
+      }
+
       const query = `
         MATCH
           (issuer:Account)-[rel1:OFFERS]->
           (acceptedCredex:Credex {credexID: $credexID})-[rel2:OFFERS]->
           (acceptor:Account)<-[:AUTHORIZED_FOR]-
           (signer:Member|Avatar { memberID: $signerID })
+        WITH issuer, rel1, acceptedCredex, rel2, acceptor, signer
+        WHERE acceptedCredex IS NOT NULL 
+          AND signer IS NOT NULL
+          AND rel1 IS NOT NULL
+          AND rel2 IS NOT NULL
         DELETE rel1, rel2
         CREATE (issuer)-[:OWES]->(acceptedCredex)-[:OWES]->(acceptor)
         SET acceptedCredex.acceptedAt = datetime()
@@ -53,22 +83,42 @@ export async function AcceptCredexService(
           signer.memberID AS signerID
       `;
 
-      const queryResult = await tx.run(query, { credexID, signerID });
+      try {
+        const queryResult = await tx.run(query, { credexID, signerID });
+        
+        if (queryResult.records.length === 0) {
+          logWarning(
+            `No matching records found for acceptance pattern. Debugging info:`,
+            { 
+              credexID, 
+              signerID, 
+              requestId,
+              summary: queryResult.summary.counters.updates()
+            }
+          );
+          return null;
+        }
 
-      if (queryResult.records.length === 0) {
-        logWarning(
-          `No records found or credex no longer pending for credexID: ${credexID}`,
-          { credexID, signerID, requestId }
+        const record = queryResult.records[0];
+        return {
+          acceptedCredexID: record.get("credexID"),
+          acceptorAccountID: record.get("acceptorAccountID"),
+          acceptorSignerID: record.get("signerID"),
+        };
+      } catch (txError) {
+        logError(
+          "Transaction error during Credex acceptance", 
+          txError as Error,
+          {
+            credexID,
+            signerID,
+            requestId,
+            errorCode: (txError as any).code,
+            errorMessage: (txError as Error).message
+          }
         );
-        return null;
+        throw txError;
       }
-
-      const record = queryResult.records[0];
-      return {
-        acceptedCredexID: record.get("credexID"),
-        acceptorAccountID: record.get("acceptorAccountID"),
-        acceptorSignerID: record.get("signerID"),
-      };
     });
 
     if (result) {
@@ -99,7 +149,17 @@ export async function AcceptCredexService(
 
     return result;
   } catch (error) {
-    logError(`Error accepting credex for credexID ${credexID}`, error as Error, { credexID, signerID, requestId });
+    logError(
+      `Error accepting credex for credexID ${credexID}`, 
+      error as Error, 
+      { 
+        credexID, 
+        signerID, 
+        requestId,
+        errorStack: (error as Error).stack,
+        errorCode: (error as any).code
+      }
+    );
     throw new Error(`Failed to accept Credex: ${(error as Error).message}`);
   } finally {
     await ledgerSpaceSession.close();

--- a/src/api/Credex/services/AcceptCredex.ts
+++ b/src/api/Credex/services/AcceptCredex.ts
@@ -69,11 +69,6 @@ export async function AcceptCredexService(
           (acceptedCredex:Credex {credexID: $credexID})-[rel2:OFFERS]->
           (acceptor:Account)<-[:AUTHORIZED_FOR]-
           (signer:Member|Avatar { memberID: $signerID })
-        WITH issuer, rel1, acceptedCredex, rel2, acceptor, signer
-        WHERE acceptedCredex IS NOT NULL 
-          AND signer IS NOT NULL
-          AND rel1 IS NOT NULL
-          AND rel2 IS NOT NULL
         DELETE rel1, rel2
         CREATE (issuer)-[:OWES]->(acceptedCredex)-[:OWES]->(acceptor)
         SET acceptedCredex.acceptedAt = datetime()

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ import AccountRoutes from "./api/Account/accountRoutes";
 import CredexRoutes from "./api/Credex/credexRoutes";
 import RecurringRoutes from "./api/Avatar/recurringRoutes";
 import DevAdminRoutes from "./api/DevAdmin/devAdminRoutes";
-import logger, { expressLogger, updateLoggerConfig } from "./utils/logger";
+import logger, { addRequestId, expressLogger, updateLoggerConfig } from "./utils/logger";
 import bodyParser from "body-parser";
 import startCronJobs from "./core-cron/cronJobs";
 import AdminDashboardRoutes from "./api/AdminDashboard/adminDashboardRoutes";
@@ -44,6 +44,9 @@ async function initializeApp() {
 
     // Apply security middleware
     applySecurityMiddleware(app);
+
+    // Add request ID middleware 
+    app.use(addRequestId)
 
     // Apply custom logging middleware
     app.use(expressLogger);

--- a/src/utils/digitalSignature.ts
+++ b/src/utils/digitalSignature.ts
@@ -17,7 +17,7 @@ export async function digitallySign(
     actionType,
     requestId,
   });
-
+  
   const query = `
     MATCH (signer:Member|Avatar {id: $signerID})
     MATCH (entity:${entityType} {id: $entityId})


### PR DESCRIPTION
- Added `addRequestId` middleware to Express app initialization before logger middleware
- Ensured `requestId` is properly passed through the AcceptCredex controller and service
- Added `requestId` to Neo4j query parameters in `digitallySign` function
### changes 
- Modified `index.ts` to include `addRequestId` middleware
- Updated `digitalSignature.ts` to include requestId in Neo4j parameters