### PR TITLE
Move getLedger to Account Module & Test Credex Flow

### DIFF
--- a/src/api/Account/accountRoutes.ts
+++ b/src/api/Account/accountRoutes.ts
@@ -5,6 +5,7 @@ import { UpdateAccountController } from "./controllers/updateAccount";
 import { AuthorizeForAccountController } from "./controllers/authorizeForAccount";
 import { UnauthorizeForAccountController } from "./controllers/unauthorizeForAccount";
 import { UpdateSendOffersToController } from "./controllers/updateSendOffersTo";
+import { GetLedgerController } from "./controllers/getLedger";
 import { errorHandler } from "../../middleware/errorHandler";
 import { validateRequest } from "../../middleware/validateRequest";
 import {
@@ -14,6 +15,7 @@ import {
   authorizeForAccountSchema,
   unauthorizeForAccountSchema,
   updateSendOffersToSchema,
+  getLedgerSchema,
 } from "./accountValidationSchemas";
 import logger from "../../utils/logger";
 
@@ -63,6 +65,14 @@ export default function AccountRoutes() {
     UpdateSendOffersToController,
     errorHandler
   );
+
+  router.post(
+    `/getLedger`,
+    validateRequest(getLedgerSchema),
+    GetLedgerController,
+    errorHandler
+  );
+  logger.debug("Route registered: POST /getLedger");
 
   logger.info("Account routes initialized successfully");
   return router;

--- a/src/api/Account/accountValidationSchemas.ts
+++ b/src/api/Account/accountValidationSchemas.ts
@@ -117,4 +117,12 @@ export const updateSendOffersToSchema = {
 };
 logger.debug("updateSendOffersToSchema initialized");
 
+export const getLedgerSchema = {
+  accountID: {
+    sanitizer: s.sanitizeUUID,
+    validator: v.validateUUID,
+  },
+};
+logger.debug("getLedgerSchema initialized");
+
 logger.debug("All account validation schemas initialized");

--- a/src/api/Account/controllers/getLedger.ts
+++ b/src/api/Account/controllers/getLedger.ts
@@ -1,0 +1,84 @@
+import express from "express";
+import { GetLedgerService } from "../services/GetLedger";
+import { validateUUID, validatePositiveInteger } from "../../../utils/validators";
+import logger from "../../../utils/logger";
+
+export const GetLedgerController = async (
+  req: express.Request,
+  res: express.Response,
+  next: express.NextFunction
+): Promise<void> => {
+  const requestId = req.id;
+  const { accountID, numRows, startRow } = req.body;
+
+  logger.debug("Entering GetLedgerController", {
+    accountID,
+    numRows,
+    startRow,
+    requestId,
+  });
+
+  try {
+    if (!validateUUID(accountID)) {
+      logger.warn("Invalid accountID", { accountID, requestId });
+      res.status(400).json({
+        message: "Invalid accountID",
+      });
+      logger.debug("Exiting GetLedgerController with invalid accountID", { requestId });
+      return;
+    }
+
+    const parsedNumRows = numRows ? parseInt(numRows as string, 10) : 10;
+    const parsedStartRow = startRow ? parseInt(startRow as string, 10) : 0;
+
+    if (!validatePositiveInteger(parsedNumRows)) {
+      logger.warn("Invalid numRows", { numRows, requestId });
+      res.status(400).json({
+        message: "Invalid numRows. Must be a positive integer.",
+      });
+      logger.debug("Exiting GetLedgerController with invalid numRows", { requestId });
+      return;
+    }
+
+    if (!Number.isInteger(parsedStartRow) || parsedStartRow < 0) {
+      logger.warn("Invalid startRow", { startRow, requestId });
+      res.status(400).json({
+        message: "Invalid startRow. Must be a non-negative integer.",
+      });
+      logger.debug("Exiting GetLedgerController with invalid startRow", { requestId });
+      return;
+    }
+
+    logger.info("Retrieving ledger", { accountID, numRows: parsedNumRows, startRow: parsedStartRow, requestId });
+
+    const responseData = await GetLedgerService(
+      accountID,
+      parsedNumRows,
+      parsedStartRow
+    );
+
+    if (responseData) {
+      logger.info("Ledger retrieved successfully", {
+        accountID,
+        numRows: parsedNumRows,
+        startRow: parsedStartRow,
+        requestId,
+      });
+      res.status(200).json(responseData);
+    } else {
+      logger.warn("Ledger not found", { accountID, requestId });
+      res.status(404).json({ message: "Ledger not found" });
+    }
+
+    logger.debug("Exiting GetLedgerController successfully", { requestId });
+  } catch (error) {
+    logger.error("Error in GetLedgerController", {
+      error: error instanceof Error ? error.message : "Unknown error",
+      stack: error instanceof Error ? error.stack : undefined,
+      accountID,
+      requestId,
+    });
+    logger.debug("Exiting GetLedgerController with error", { requestId });
+    next(error);
+  }
+};

--- a/src/api/Account/services/GetLedger.ts
+++ b/src/api/Account/services/GetLedger.ts
@@ -1,0 +1,78 @@
+import * as neo4j from "neo4j-driver";
+import { ledgerSpaceDriver } from "../../../../config/neo4j";
+import { denomFormatter } from "../../../utils/denomUtils";
+import { logDebug, logInfo, logWarning, logError } from "../../../utils/logger";
+
+export async function GetLedgerService(
+  accountID: string,
+  numRows: number = 10,
+  startRow: number = 0
+) {
+  logDebug(`Entering GetLedgerService`, { accountID, numRows, startRow });
+
+  numRows = Math.round(Number(numRows));
+  startRow = Math.round(Number(startRow));
+
+  if (Number.isNaN(numRows) || Number.isNaN(startRow)) {
+    logWarning(`Invalid numRows or startRow`, { accountID, numRows, startRow });
+    return "numRows and startRows must be numbers";
+  }
+
+  try {
+    logDebug(`Attempting to fetch ledger data from database`, { accountID, numRows, startRow });
+    const ledgerSpaceSession = ledgerSpaceDriver.session();
+    const result = await ledgerSpaceSession.run(
+      `
+        OPTIONAL MATCH
+            (account:Account{accountID:$accountID})-[transactionType:OWES|CLEARED]-(credex:Credex)-[:OWES|CLEARED]-(counterparty:Account)
+        OPTIONAL MATCH (credex)<-[:SECURES]-(securer:Account)
+        RETURN
+            credex.credexID AS credexID,
+            credex.InitialAmount/credex.CXXmultiplier AS InitialAmount,
+            credex.Denomination AS Denomination,
+            (startNode(transactionType) = account) as debit,
+            counterparty.accountName AS counterpartyAccountName
+            ORDER BY credex.acceptedAt
+            SKIP $startRow
+            LIMIT $numRows
+    `,
+      {
+        accountID: accountID,
+        numRows: neo4j.int(numRows),
+        startRow: neo4j.int(startRow),
+      }
+    );
+
+    await ledgerSpaceSession.close();
+
+    if (!result.records[0].get("credexID")) {
+      logInfo(`No credexes found for account`, { accountID });
+      return {};
+    }
+
+    const credexes = result.records.map((record) => {
+      const credexID = record.get("credexID");
+      const InitialAmount = record.get("debit")
+        ? -parseFloat(record.get("InitialAmount"))
+        : record.get("InitialAmount");
+      const Denomination = record.get("Denomination");
+      const counterpartyAccountName = record.get("counterpartyAccountName");
+
+      const formattedInitialAmount =
+        denomFormatter(InitialAmount, Denomination) + " " + Denomination;
+
+      return {
+        credexID,
+        formattedInitialAmount,
+        counterpartyAccountName,
+      };
+    });
+
+    logInfo(`Successfully fetched ledger data`, { accountID, credexCount: credexes.length });
+    logDebug(`Exiting GetLedgerService`, { accountID });
+    return credexes;
+  } catch (error) {
+    logError(`Error in GetLedgerService:`, error as Error, { accountID, numRows, startRow });
+    throw error;
+  }
+}

--- a/tests/api/utils/auth.ts
+++ b/tests/api/utils/auth.ts
@@ -24,7 +24,7 @@ export const loginMember = async (phone: string): Promise<{jwt: string, memberID
 
     return {
       jwt: loginResponse.data.token,
-      memberID: dashboardResponse.data.memberID
+      memberID: dashboardResponse.data.memberDashboard.memberID
     };
   } catch (err) {
     const error = err as AxiosError;

--- a/tests/api/utils/endpoints/credex.ts
+++ b/tests/api/utils/endpoints/credex.ts
@@ -25,6 +25,8 @@ export async function createCredex(
   }, jwt);
   console.log("Create credex response:", response.data);
   expect(response.status).toBe(200);
+  expect(response.data.createCredexData).toBeTruthy();
+  expect(response.data.dashboardData).toBeTruthy();
   await delay(DELAY_MS);
   return response;
 }

--- a/tests/api/utils/request.ts
+++ b/tests/api/utils/request.ts
@@ -7,5 +7,8 @@ export const authRequest = async (endpoint: string, data: any, token?: string) =
         headers: { Authorization: `Bearer ${token}` },
       }
     : {};
+  console.log("Making request to:", endpoint);
+  console.log("With data:", data);
+  console.log("And config:", config);
   return axios.post(endpoint, data, config);
 };


### PR DESCRIPTION
## Changes Made

### 1. Moved getLedger from Credex to Account Module
- Moved getLedger endpoint from Credex to Account module to better align with domain responsibilities
- Moved related files:
  - Controller: `src/api/Account/controllers/getLedger.ts`
  - Service: `src/api/Account/services/GetLedger.ts`
  - Added schema: `getLedgerSchema` to `src/api/Account/accountValidationSchemas.ts`
  - Updated routes: Added getLedger route to `src/api/Account/accountRoutes.ts`
- Maintained exact functionality while moving to ensure compatibility
- Cleaned up old getLedger code from Credex module:
   - Removed getLedger controller
   - Removed getLedger service
   - Removed getLedger schema
   - Removed getLedger route

### 2. Fixed and Tested createCredex Flow
- Fixed issues in test utilities:
  - Updated loginMember to correctly extract memberID from dashboard response
  - Fixed syntax errors in createCredex test utility
  - Added proper validation for both createCredexData and dashboardData in response
- Successfully tested createCredex with:
  - issuerAccountID: 791897c4-5b92-4beb-9092-8a37d258f693
  - receiverAccountID: 764f859f-e0b8-4bef-a883-5b2f416035a9
  - Created credex: 088358b4-2e99-49d2-8100-fad7067d4bef

## Testing Done
1. Verified getLedger endpoint works in Account module (correctly returning empty with no credexes created)
2. Successfully ran createCredex test with proper authorization and data validation
3. Confirmed both createCredexData and dashboardData are returned correctly

## Remaining Work
Continue with Credex flow testing:
   - acceptcredex with credexID: 088358b4-2e99-49d2-8100-fad7067d4bef
   - acceptcredexbulk
   - declinecredex
   - cancelcredex
   - getcredex