### PR TITLE
loops isolated per trust account

### DIFF
--- a/docs/due-diligence/MTQ.html
+++ b/docs/due-diligence/MTQ.html
@@ -136,8 +136,8 @@
         <strong>Secured Credexes:</strong>
         <ul>
           <li>
-            Use denomination-specific relationship types (e.g., "USD_SECURED",
-            "EUR_SECURED")
+            Use trust account-specific relationship types in format "TRUST_[shortID]_[denomination]"
+            where shortID is first 12 characters of trust account UUID
           </li>
           <li>Due dates are automatically adjusted to the current day</li>
           <li>Maintain separate loop paths from unsecured credexes</li>
@@ -154,7 +154,7 @@
         <ul>
           <li>Act as intermediaries between accounts</li>
           <li>Maintain the earliest due date among connected credexes</li>
-          <li>Separate paths by relationship type (secured vs unsecured)</li>
+          <li>Separate paths by relationship type (unsecured vs trust-specific secured)</li>
           <li>Automatically created and removed as needed</li>
         </ul>
       </li>
@@ -203,15 +203,15 @@
 
     Properties:
     - Search Anchor: Maintains earliestDueDate among connected credexes
-    - Relationship Types: Either UNSECURED or [DENOMINATION]_SECURED
+    - Relationship Types: Either UNSECURED or TRUST_[shortID]_[denomination]
     - Multiple credexes can connect to the same search anchor
     - Search anchors are created per relationship type between accounts
 
     Example Loop:
-    [Account A] --USD_SECURED--> [Anchor 1] --USD_SECURED--> [Account B]
-         ^                                                        |
-         |                                                        |
-         +------------------------USD_SECURED---------------------+
+    [Account A] --TRUST_abc123_USD--> [Anchor 1] --TRUST_abc123_USD--> [Account B]
+         ^                                                                  |
+         |                                                                  |
+         +------------------------TRUST_abc123_USD---------------------------+
     </pre>
 
     <h3>Loop Finding Algorithm</h3>

--- a/docs/due-diligence/trust_account_audits.html
+++ b/docs/due-diligence/trust_account_audits.html
@@ -99,7 +99,38 @@
       </li>
     </ol>
 
-    <h2>How We Keep Things Safe</h2>
+      <h2>Trust-Specific Transaction Handling</h2>
+      <p>
+        The system maintains strict separation between different trust accounts' transactions:
+      </p>
+      <ul>
+        <li>
+          <strong>Isolated Transaction Paths:</strong>
+          <ul>
+            <li>Each trust account has its own unique transaction paths in the system</li>
+            <li>Secured credexes can only form loops with other credexes from the same trust account</li>
+            <li>This ensures proper accounting and maintains the direct link between real assets and secured balances</li>
+          </ul>
+        </li>
+        <li>
+          <strong>Trust-Specific Identifiers:</strong>
+          <ul>
+            <li>Each trust account gets a unique identifier in the system</li>
+            <li>All transactions are tagged with this identifier</li>
+            <li>Makes it easy to track and verify all movements within each trust account</li>
+          </ul>
+        </li>
+        <li>
+          <strong>Automated Separation:</strong>
+          <ul>
+            <li>The system automatically keeps different trust accounts' transactions separate</li>
+            <li>Prevents any accidental mixing of secured credexes from different trust accounts</li>
+            <li>Maintains clear audit trails for each trust account</li>
+          </ul>
+        </li>
+      </ul>
+
+      <h2>How We Keep Things Safe</h2>
     <p>
       The system has multiple safety features, like a lockbox with several different locks:
     </p>

--- a/docs/member-guides/trust_secured.html
+++ b/docs/member-guides/trust_secured.html
@@ -30,6 +30,13 @@
           </ul>
         </li>
 
+      <h2>Trust Account Protection</h2>
+      <ul>
+        <li>Each trust account operates in its own secure lane - like having separate lockboxes for different savings clubs</li>
+        <li>Your secured credexes only interact with others from the same trust account - ensuring clear tracking of real assets</li>
+        <li>The system automatically keeps everything organized - you don't have to worry about which trust account to use</li>
+      </ul>
+
       <h2>Double-Entry Protection</h2>
       <ul>
         <li>It's like having two trusted elders keeping separate record books</li>

--- a/src/core-cron/MTQ/LoopFinder.ts
+++ b/src/core-cron/MTQ/LoopFinder.ts
@@ -19,7 +19,8 @@ export async function LoopFinder(
   CXXmultiplier: number,
   credexSecuredDenom: string,
   credexDueDate: string,
-  acceptorAccountID: string
+  acceptorAccountID: string,
+  trustAccountID?: string
 ): Promise<boolean> {
   logger.info("LoopFinder started", {
     issuerAccountID,
@@ -34,7 +35,7 @@ export async function LoopFinder(
   };
 
   try {
-    const searchOwesType = getSearchOwesType(credexSecuredDenom);
+    const searchOwesType = getSearchOwesType(credexSecuredDenom, trustAccountID);
     credexDueDate = await adjustCredexDueDate(
       sessions.ledgerSpaceSession,
       credexSecuredDenom,

--- a/src/core-cron/MTQ/LoopFinderUtils.ts
+++ b/src/core-cron/MTQ/LoopFinderUtils.ts
@@ -1,10 +1,14 @@
 import * as neo4j from "neo4j-driver";
 import logger from "../../utils/logger";
 
-export function getSearchOwesType(credexSecuredDenom: string): string {
-  return credexSecuredDenom !== "floating"
-    ? `${credexSecuredDenom}_SECURED`
-    : "UNSECURED";
+export function getSearchOwesType(credexSecuredDenom: string, trustAccountID?: string): string {
+  if (credexSecuredDenom === "UNSECURED") {
+    return "UNSECURED";
+  }
+  
+  // Take first 12 chars of UUID and remove hyphens
+  const shortID = trustAccountID?.substring(0, 12).replace(/-/g, '');
+  return `TRUST_${shortID}_${credexSecuredDenom}`;
 }
 
 export async function adjustCredexDueDate(
@@ -16,7 +20,7 @@ export async function adjustCredexDueDate(
     credexSecuredDenom,
     credexDueDate,
   });
-  if (credexSecuredDenom !== "floating") {
+  if (credexSecuredDenom !== "UNSECURED") {
     const result = await session.run(`
       MATCH (daynode:Daynode {Active: true})
       RETURN daynode.Date AS today

--- a/src/core-cron/MTQ/MinuteTransactionQueue.ts
+++ b/src/core-cron/MTQ/MinuteTransactionQueue.ts
@@ -19,6 +19,7 @@ interface Credex {
   CXXmultiplier: number;
   credexSecuredDenom: string;
   dueDate: string;
+  trustAccountID?: string;
 }
 
 export async function MinuteTransactionQueue(): Promise<boolean> {
@@ -253,7 +254,8 @@ async function processQueuedCredexes(
         credex.CXXmultiplier,
         credex.credexSecuredDenom,
         credex.dueDate,
-        credex.acceptorAccountID
+        credex.acceptorAccountID,
+        credex.trustAccountID
       );
       logger.debug("Credex processed successfully", {
         credexID: credex.credexID,
@@ -280,7 +282,7 @@ async function getQueuedCredexes(session: any): Promise<Credex[]> {
     RETURN queuedCredex.acceptedAt AS acceptedAt,
            issuerAccount.accountID AS issuerAccountID,
            acceptorAccount.accountID AS acceptorAccountID,
-           securer.accountID AS securerID,
+           securer.accountID AS trustAccountID,
            queuedCredex.credexID AS credexID,
            queuedCredex.InitialAmount AS amount,
            queuedCredex.Denomination AS denomination,
@@ -303,9 +305,10 @@ async function getQueuedCredexes(session: any): Promise<Credex[]> {
       denomination: record.get("denomination"),
       CXXmultiplier: typeof CXXmultiplier?.toNumber === 'function' ? CXXmultiplier.toNumber() : Number(CXXmultiplier),
       credexSecuredDenom:
-        record.get("securerID") !== null
+        record.get("trustAccountID") !== null
           ? record.get("denomination")
-          : "floating",
+          : "UNSECURED",
+      trustAccountID: record.get("trustAccountID"),
       dueDate: record.get("dueDate"),
     };
   });


### PR DESCRIPTION
## Overview
This merge introduces trust account-specific loop handling in the MTQ (Minute Transaction Queue) system. The changes modify how secured denominations are tracked and processed, adding support for trust account-specific loops instead of the previous denomination-specific loops.

## Changed Files
1. `src/core-cron/MTQ/LoopFinder.ts`
2. `src/core-cron/MTQ/LoopFinderUtils.ts`
3. `src/core-cron/MTQ/MinuteTransactionQueue.ts`

## Key Changes

### Trust Account Integration
- Added optional `trustAccountID` parameter to the LoopFinder function
- Modified secured denomination handling to include trust account information
- Updated type definitions to support trust account IDs in Credex interfaces

### Denomination Handling
- Changed "floating" denomination to "UNSECURED" for better semantic clarity
- Introduced new format for secured denominations: `TRUST_[shortID]_[denomination]`
  - shortID: First 12 characters of trust account UUID (hyphens removed)

### Database Query Updates
- Updated Neo4j query to return trust account information
- Renamed `securerID` to `trustAccountID` for consistency
- Modified credex processing to include trust account context

## Technical Details
1. **LoopFinder.ts**
   - Added `trustAccountID` as optional parameter
   - Updated function signature and parameter passing

2. **LoopFinderUtils.ts**
   - Refactored `getSearchOwesType` to handle trust-specific denomination formats
   - Updated denomination type checking logic
   - Modified date adjustment logic to use "UNSECURED" constant

3. **MinuteTransactionQueue.ts**
   - Added `trustAccountID` to Credex interface
   - Updated queue processing to include trust account information
   - Modified database query field mapping

## Impact
These changes enable more granular tracking of secured transactions per trust account, improving the system's ability to handle multiple trust accounts with different secured denominations.
