### PR TITLE
Fixed OTP max daily retries

### DIFF
--- a/src/api/Member/services/verification/verificationService.ts
+++ b/src/api/Member/services/verification/verificationService.ts
@@ -422,8 +422,31 @@ export class VerificationService {
       }
 
       const record = result.records[0];
-      const requests = record.get('requests') || 0;
+      let requests = record.get('requests') || 0;
       const lastRequest = record.get('lastRequest');
+
+      // Check if last request was on a previous day and reset counter if needed
+      if (lastRequest) {
+        const lastRequestDate = new Date(lastRequest);
+        const today = new Date();
+        
+        // Check if the last request was on a different day
+        if (lastRequestDate.getUTCDate() !== today.getUTCDate() ||
+            lastRequestDate.getUTCMonth() !== today.getUTCMonth() ||
+            lastRequestDate.getUTCFullYear() !== today.getUTCFullYear()) {
+          
+          // Reset the counter in the database
+          await session.run(
+            `MATCH (m:Member {memberID: $memberID})
+             SET m.otpRequestsToday = 0`,
+            { memberID }
+          );
+          
+          // Update local variable for subsequent checks
+          requests = 0;
+          logger.info('Reset daily OTP request counter', { memberID });
+        }
+      }
 
       // Check daily limit
       if (requests >= this.config.maxDailyRequests) {

--- a/tests/api/whatsappOtp.test.ts
+++ b/tests/api/whatsappOtp.test.ts
@@ -129,4 +129,126 @@ describe("OTP Verification Tests", () => {
       expect(secondResult.error?.code).toBe('RATE_LIMITED');
     });
   });
+
+  describe("OTP Rate Limiting Reset", () => {
+    it("should reset OTP counter when the last request was on a previous day", async () => {
+      // Create a test member
+      const session = ledgerSpaceDriver.session();
+      const phone = generateRandomPhone();
+      const memberID = "test-otp-reset-member";
+      
+      try {
+        // Create member with max daily requests reached but last request was yesterday
+        const yesterday = new Date();
+        yesterday.setDate(yesterday.getDate() - 1);
+        
+        await session.run(`
+          CREATE (m:Member {
+            memberID: $memberID,
+            phone: $phone,
+            version: 'v2',
+            authMethod: 'password',
+            firstname: 'Test',
+            lastname: 'User',
+            passwordHash: $passwordHash,
+            memberHandle: $phone,
+            otpRequestsToday: 5,
+            lastOtpRequest: $lastRequest
+          })
+        `, { 
+          memberID, 
+          phone,
+          passwordHash: '$2b$12$YdTBeOaejdkw2IPKYGyDKeFcFycQgNXQ69Y2IIfHpHa9uRk2C.pY6',
+          lastRequest: yesterday.toISOString()
+        });
+      } finally {
+        await session.close();
+      }
+
+      TestCleanup.trackMember(memberID, phone);
+
+      // Send OTP - should succeed because last request was yesterday and counter should be reset
+      const result = await verificationService.sendOTP(memberID, phone);
+      
+      // Verify that the OTP was sent successfully
+      expect(result.success).toBe(true);
+      expect(result.message).toBe('OTP sent successfully');
+      
+      // Verify the counter was reset in the database
+      const verifySession = ledgerSpaceDriver.session();
+      try {
+        const verifyResult = await verifySession.run(
+          `MATCH (m:Member {memberID: $memberID}) RETURN m.otpRequestsToday as requests`,
+          { memberID }
+        );
+        
+        // Should be reset to 0 and then incremented to 1 (since we sent an OTP)
+        const requests = verifyResult.records[0].get('requests');
+        expect(requests.low).toBe(1);
+        expect(requests.high).toBe(0);
+      } finally {
+        await verifySession.close();
+      }
+    });
+
+    it("should not reset OTP counter when the last request was today", async () => {
+      // Create a test member
+      const session = ledgerSpaceDriver.session();
+      const phone = generateRandomPhone();
+      const memberID = "test-otp-no-reset-member";
+      
+      try {
+        // Create member with max daily requests reached and last request was today
+        const today = new Date();
+        
+        await session.run(`
+          CREATE (m:Member {
+            memberID: $memberID,
+            phone: $phone,
+            version: 'v2',
+            authMethod: 'password',
+            firstname: 'Test',
+            lastname: 'User',
+            passwordHash: $passwordHash,
+            memberHandle: $phone,
+            otpRequestsToday: 5,
+            lastOtpRequest: $lastRequest
+          })
+        `, { 
+          memberID, 
+          phone,
+          passwordHash: '$2b$12$YdTBeOaejdkw2IPKYGyDKeFcFycQgNXQ69Y2IIfHpHa9uRk2C.pY6',
+          lastRequest: today.toISOString()
+        });
+      } finally {
+        await session.close();
+      }
+
+      TestCleanup.trackMember(memberID, phone);
+
+      // Send OTP - should fail because max requests reached today
+      const result = await verificationService.sendOTP(memberID, phone);
+      
+      // Verify that the OTP was not sent due to rate limiting
+      expect(result.success).toBe(false);
+      expect(result.error?.code).toBe('RATE_LIMITED');
+      expect(result.message).toBe('Daily OTP request limit exceeded');
+      
+      // Verify the counter was NOT reset in the database
+      const verifySession = ledgerSpaceDriver.session();
+      try {
+        const verifyResult = await verifySession.run(
+          `MATCH (m:Member {memberID: $memberID}) RETURN m.otpRequestsToday as requests`,
+          { memberID }
+        );
+        
+        // Should still be 5
+        const requests = verifyResult.records[0].get('requests');
+        expect(requests.low).toBe(5);
+        expect(requests.high).toBe(0);
+      } finally {
+        await verifySession.close();
+      }
+    });
+  });
 });


### PR DESCRIPTION
# Fix OTP Rate Limiting Reset

## PR Details
- **Branch**: feature/fix-otp-rate-limiting-reset
- **Target**: dev
- **Priority**: High
- **Type**: Bug Fix

## Problem Description

Users who reached their daily OTP request limit were getting locked out indefinitely. The issue was identified in the `checkRateLimits` method of the `VerificationService` class. When a user reached their daily OTP request limit (default is 5 requests per day), they would receive a "Daily OTP request limit exceeded" error with a "Please try again tomorrow" message. However, the `otpRequestsToday` counter was never reset when a new day began, causing users to remain locked out indefinitely.

This issue was reported by clients with the following logs:

```
flutter                 com.vimbisopay.vimbisopay_app.debug  I  RESPONSE BODY START ==================
flutter                 com.vimbisopay.vimbisopay_app.debug  I  {
flutter                 com.vimbisopay.vimbisopay_app.debug  I    "message": "Daily OTP request limit exceeded",
flutter                 com.vimbisopay.vimbisopay_app.debug  I    "data": {
flutter                 com.vimbisopay.vimbisopay_app.debug  I      "action": {
flutter                 com.vimbisopay.vimbisopay_app.debug  I        "id": null,
flutter                 com.vimbisopay.vimbisopay_app.debug  I        "type": "ERROR_VALIDATION",
flutter                 com.vimbisopay.vimbisopay_app.debug  I        "timestamp": "2025-04-22T19:37:56.287Z",
flutter                 com.vimbisopay.vimbisopay_app.debug  I        "actor": "b2c1cb55-c8c6-4f7a-be21-e3ba1d28b2a9",
flutter                 com.vimbisopay.vimbisopay_app.debug  I        "details": {
flutter                 com.vimbisopay.vimbisopay_app.debug  I          "code": "RATE_LIMITED",
flutter                 com.vimbisopay.vimbisopay_app.debug  I          "reason": "Please try again tomorrow"
flutter                 com.vimbisopay.vimbisopay_app.debug  I        }
flutter                 com.vimbisopay.vimbisopay_app.debug  I      }
flutter                 com.vimbisopay.vimbisopay_app.debug  I    }
flutter                 com.vimbisopay.vimbisopay_app.debug  I  }
flutter                 com.vimbisopay.vimbisopay_app.debug  I  RESPONSE BODY END ====================
flutter                 com.vimbisopay.vimbisopay_app.debug  I  RESPONSE LOG END ====================
flutter                 com.vimbisopay.vimbisopay_app.debug  I  [VimbisoPay/❌ ERROR] [2025-04-22T20:37:58.351215] [REQUEST_OTP] Daily limit exceeded
flutter                 com.vimbisopay.vimbisopay_app.debug  I  [VimbisoPay/❌ ERROR] Error details: Code: RATE_LIMITED, Reason: Please try again tomorrow
```

Even after waiting until the next day, users were still unable to request new OTPs.

## Solution

I added date comparison logic to the `checkRateLimits` method to detect when the last request was on a previous day and reset the counter accordingly:

```typescript
// Check if last request was on a previous day and reset counter if needed
if (lastRequest) {
  const lastRequestDate = new Date(lastRequest);
  const today = new Date();
  
  // Check if the last request was on a different day
  if (lastRequestDate.getUTCDate() !== today.getUTCDate() ||
      lastRequestDate.getUTCMonth() !== today.getUTCMonth() ||
      lastRequestDate.getUTCFullYear() !== today.getUTCFullYear()) {
    
    // Reset the counter in the database
    await session.run(
      `MATCH (m:Member {memberID: $memberID})
       SET m.otpRequestsToday = 0`,
      { memberID }
    );
    
    // Update local variable for subsequent checks
    requests = 0;
    logger.info('Reset daily OTP request counter', { memberID });
  }
}
```

This solution:
1. Compares the date of the last OTP request with the current date
2. If they are different (i.e., the last request was on a previous day), resets the counter to 0
3. Logs the reset action for monitoring purposes

## Testing

I added comprehensive tests to verify the fix and integrated them into the existing WhatsApp OTP test suite:

1. A test that verifies the counter is reset when the last request was on a previous day:
   - Creates a test member with max daily requests reached but last request was yesterday
   - Sends an OTP request
   - Verifies that the request succeeds
   - Checks the database to confirm the counter was reset and then incremented to 1

2. A test that verifies the counter is not reset when the last request was on the same day:
   - Creates a test member with max daily requests reached and last request was today
   - Sends an OTP request
   - Verifies that the request fails with the appropriate error code
   - Checks the database to confirm the counter was not reset

All tests are now passing, confirming that:
- When a user has reached their daily limit but the last request was yesterday, the counter is reset to 0 and they can request new OTPs
- When a user has reached their daily limit and the last request was today, they remain locked out until the next day

## Changes Made

1. Modified `src/api/Member/services/verification/verificationService.ts`:
   - Added date comparison logic to the `checkRateLimits` method
   - Added code to reset the counter when appropriate
   - Added logging for the reset action

2. Added tests to `tests/api/whatsappOtp.test.ts`:
   - Added a new test section "OTP Rate Limiting Reset"
   - Added two tests to verify the reset functionality

3. Removed `tests/api/Member/services/verification/otpRateLimiting.test.ts`:
   - Consolidated all OTP-related tests in the main WhatsApp OTP test suite

## Impact

This fix ensures that users can proceed with OTP requests when the time limit has passed, as required. It maintains the security benefits of rate limiting while preventing the unintended side effect of indefinite lockouts.

## Deployment Notes

This change does not require any database migrations or configuration changes. It is a self-contained fix that will take effect immediately upon deployment.
